### PR TITLE
Add .NET Aspire microservices backend for DeadStock Hair

### DIFF
--- a/DeadStockHair.sln
+++ b/DeadStockHair.sln
@@ -1,0 +1,84 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72D-47B6-A68D-7590B98EB39B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DeadStockHair.ServiceDefaults", "src\DeadStockHair.ServiceDefaults\DeadStockHair.ServiceDefaults.csproj", "{FC79BEA7-2195-4C34-866A-0737788A843B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DeadStockHair.AppHost", "src\DeadStockHair.AppHost\DeadStockHair.AppHost.csproj", "{D632256C-D950-4636-8E6B-197B0D7E03FA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DeadStockHair.Api", "src\DeadStockHair.Api\DeadStockHair.Api.csproj", "{EBFE08BC-D6BC-4BB4-83A9-CA30139EE264}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DeadStockHair.Cli", "src\DeadStockHair.Cli\DeadStockHair.Cli.csproj", "{7C414735-A24F-4C0A-991A-5B1DACC68D4A}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{FC79BEA7-2195-4C34-866A-0737788A843B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FC79BEA7-2195-4C34-866A-0737788A843B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FC79BEA7-2195-4C34-866A-0737788A843B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FC79BEA7-2195-4C34-866A-0737788A843B}.Debug|x64.Build.0 = Debug|Any CPU
+		{FC79BEA7-2195-4C34-866A-0737788A843B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FC79BEA7-2195-4C34-866A-0737788A843B}.Debug|x86.Build.0 = Debug|Any CPU
+		{FC79BEA7-2195-4C34-866A-0737788A843B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FC79BEA7-2195-4C34-866A-0737788A843B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FC79BEA7-2195-4C34-866A-0737788A843B}.Release|x64.ActiveCfg = Release|Any CPU
+		{FC79BEA7-2195-4C34-866A-0737788A843B}.Release|x64.Build.0 = Release|Any CPU
+		{FC79BEA7-2195-4C34-866A-0737788A843B}.Release|x86.ActiveCfg = Release|Any CPU
+		{FC79BEA7-2195-4C34-866A-0737788A843B}.Release|x86.Build.0 = Release|Any CPU
+		{D632256C-D950-4636-8E6B-197B0D7E03FA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D632256C-D950-4636-8E6B-197B0D7E03FA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D632256C-D950-4636-8E6B-197B0D7E03FA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D632256C-D950-4636-8E6B-197B0D7E03FA}.Debug|x64.Build.0 = Debug|Any CPU
+		{D632256C-D950-4636-8E6B-197B0D7E03FA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D632256C-D950-4636-8E6B-197B0D7E03FA}.Debug|x86.Build.0 = Debug|Any CPU
+		{D632256C-D950-4636-8E6B-197B0D7E03FA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D632256C-D950-4636-8E6B-197B0D7E03FA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D632256C-D950-4636-8E6B-197B0D7E03FA}.Release|x64.ActiveCfg = Release|Any CPU
+		{D632256C-D950-4636-8E6B-197B0D7E03FA}.Release|x64.Build.0 = Release|Any CPU
+		{D632256C-D950-4636-8E6B-197B0D7E03FA}.Release|x86.ActiveCfg = Release|Any CPU
+		{D632256C-D950-4636-8E6B-197B0D7E03FA}.Release|x86.Build.0 = Release|Any CPU
+		{EBFE08BC-D6BC-4BB4-83A9-CA30139EE264}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EBFE08BC-D6BC-4BB4-83A9-CA30139EE264}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EBFE08BC-D6BC-4BB4-83A9-CA30139EE264}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{EBFE08BC-D6BC-4BB4-83A9-CA30139EE264}.Debug|x64.Build.0 = Debug|Any CPU
+		{EBFE08BC-D6BC-4BB4-83A9-CA30139EE264}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{EBFE08BC-D6BC-4BB4-83A9-CA30139EE264}.Debug|x86.Build.0 = Debug|Any CPU
+		{EBFE08BC-D6BC-4BB4-83A9-CA30139EE264}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EBFE08BC-D6BC-4BB4-83A9-CA30139EE264}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EBFE08BC-D6BC-4BB4-83A9-CA30139EE264}.Release|x64.ActiveCfg = Release|Any CPU
+		{EBFE08BC-D6BC-4BB4-83A9-CA30139EE264}.Release|x64.Build.0 = Release|Any CPU
+		{EBFE08BC-D6BC-4BB4-83A9-CA30139EE264}.Release|x86.ActiveCfg = Release|Any CPU
+		{EBFE08BC-D6BC-4BB4-83A9-CA30139EE264}.Release|x86.Build.0 = Release|Any CPU
+		{7C414735-A24F-4C0A-991A-5B1DACC68D4A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7C414735-A24F-4C0A-991A-5B1DACC68D4A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7C414735-A24F-4C0A-991A-5B1DACC68D4A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7C414735-A24F-4C0A-991A-5B1DACC68D4A}.Debug|x64.Build.0 = Debug|Any CPU
+		{7C414735-A24F-4C0A-991A-5B1DACC68D4A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7C414735-A24F-4C0A-991A-5B1DACC68D4A}.Debug|x86.Build.0 = Debug|Any CPU
+		{7C414735-A24F-4C0A-991A-5B1DACC68D4A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7C414735-A24F-4C0A-991A-5B1DACC68D4A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7C414735-A24F-4C0A-991A-5B1DACC68D4A}.Release|x64.ActiveCfg = Release|Any CPU
+		{7C414735-A24F-4C0A-991A-5B1DACC68D4A}.Release|x64.Build.0 = Release|Any CPU
+		{7C414735-A24F-4C0A-991A-5B1DACC68D4A}.Release|x86.ActiveCfg = Release|Any CPU
+		{7C414735-A24F-4C0A-991A-5B1DACC68D4A}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{FC79BEA7-2195-4C34-866A-0737788A843B} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{D632256C-D950-4636-8E6B-197B0D7E03FA} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{EBFE08BC-D6BC-4BB4-83A9-CA30139EE264} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{7C414735-A24F-4C0A-991A-5B1DACC68D4A} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+	EndGlobalSection
+EndGlobal

--- a/src/DeadStockHair.Api/Data/RetailerStore.cs
+++ b/src/DeadStockHair.Api/Data/RetailerStore.cs
@@ -1,0 +1,138 @@
+using System.Collections.Concurrent;
+using DeadStockHair.Api.Models;
+
+namespace DeadStockHair.Api.Data;
+
+public class RetailerStore
+{
+    private readonly ConcurrentDictionary<Guid, Retailer> _retailers = new();
+    private readonly ConcurrentDictionary<Guid, SavedRetailer> _savedRetailers = new();
+    private readonly ConcurrentDictionary<Guid, ScanResult> _scans = new();
+
+    public RetailerStore()
+    {
+        SeedData();
+    }
+
+    private void SeedData()
+    {
+        var retailers = new[]
+        {
+            new Retailer { Name = "DROP DEAD Extensions", Url = "dropdeadextensions.com", Status = RetailerStatus.InStock },
+            new Retailer { Name = "Hair Overstock", Url = "hairoverstock.com", Status = RetailerStatus.InStock },
+            new Retailer { Name = "Viola Hair Extensions", Url = "violahairextensions.co", Status = RetailerStatus.InStock },
+            new Retailer { Name = "ParaHair Canada", Url = "parahair.ca", Status = RetailerStatus.InStock },
+            new Retailer { Name = "Golden Lush Extensions", Url = "goldenlushextensions.com", Status = RetailerStatus.InStock },
+            new Retailer { Name = "Chiquel Hair", Url = "chiquel.ca", Status = RetailerStatus.InStock, DiscoveredAt = DateTime.UtcNow.AddDays(-2) },
+            new Retailer { Name = "Luxe Strand Co", Url = "luxestrand.com", Status = RetailerStatus.OutOfStock },
+            new Retailer { Name = "Mane District", Url = "manedistrict.com", Status = RetailerStatus.OutOfStock },
+            new Retailer { Name = "Crown & Glory Hair", Url = "crownandgloryhair.com", Status = RetailerStatus.InStock, DiscoveredAt = DateTime.UtcNow.AddDays(-5) },
+            new Retailer { Name = "Silk Roots Boutique", Url = "silkrootsboutique.com", Status = RetailerStatus.Unknown, DiscoveredAt = DateTime.UtcNow.AddDays(-1) },
+        };
+
+        foreach (var retailer in retailers)
+        {
+            _retailers[retailer.Id] = retailer;
+        }
+    }
+
+    // Retailers
+    public IReadOnlyList<Retailer> GetAllRetailers() =>
+        _retailers.Values.OrderByDescending(r => r.DiscoveredAt).ToList();
+
+    public IReadOnlyList<Retailer> SearchRetailers(string query) =>
+        _retailers.Values
+            .Where(r => r.Name.Contains(query, StringComparison.OrdinalIgnoreCase)
+                     || r.Url.Contains(query, StringComparison.OrdinalIgnoreCase))
+            .OrderByDescending(r => r.DiscoveredAt)
+            .ToList();
+
+    public Retailer? GetRetailer(Guid id) =>
+        _retailers.GetValueOrDefault(id);
+
+    public Retailer AddRetailer(Retailer retailer)
+    {
+        _retailers[retailer.Id] = retailer;
+        return retailer;
+    }
+
+    public bool DeleteRetailer(Guid id) =>
+        _retailers.TryRemove(id, out _);
+
+    public RetailerStats GetStats()
+    {
+        var all = _retailers.Values.ToList();
+        var oneWeekAgo = DateTime.UtcNow.AddDays(-7);
+        return new RetailerStats(
+            TotalRetailers: all.Count,
+            InStock: all.Count(r => r.Status == RetailerStatus.InStock),
+            NewThisWeek: all.Count(r => r.DiscoveredAt >= oneWeekAgo)
+        );
+    }
+
+    // Saved Retailers
+    public IReadOnlyList<Retailer> GetSavedRetailers()
+    {
+        var savedIds = _savedRetailers.Values.Select(s => s.RetailerId).ToHashSet();
+        return _retailers.Values
+            .Where(r => savedIds.Contains(r.Id))
+            .OrderByDescending(r => r.DiscoveredAt)
+            .ToList();
+    }
+
+    public SavedRetailer? SaveRetailer(Guid retailerId)
+    {
+        if (!_retailers.ContainsKey(retailerId))
+            return null;
+
+        if (_savedRetailers.Values.Any(s => s.RetailerId == retailerId))
+            return _savedRetailers.Values.First(s => s.RetailerId == retailerId);
+
+        var saved = new SavedRetailer { RetailerId = retailerId };
+        _savedRetailers[saved.Id] = saved;
+        return saved;
+    }
+
+    public bool UnsaveRetailer(Guid retailerId)
+    {
+        var saved = _savedRetailers.Values.FirstOrDefault(s => s.RetailerId == retailerId);
+        if (saved == null) return false;
+        return _savedRetailers.TryRemove(saved.Id, out _);
+    }
+
+    public bool IsRetailerSaved(Guid retailerId) =>
+        _savedRetailers.Values.Any(s => s.RetailerId == retailerId);
+
+    // Scans
+    public ScanResult CreateScan()
+    {
+        var scan = new ScanResult { Status = ScanStatus.Running };
+        _scans[scan.Id] = scan;
+        return scan;
+    }
+
+    public ScanResult? GetScan(Guid id) =>
+        _scans.GetValueOrDefault(id);
+
+    public ScanResult? GetLatestScan() =>
+        _scans.Values.OrderByDescending(s => s.StartedAt).FirstOrDefault();
+
+    public void CompleteScan(Guid id, int retailersFound)
+    {
+        if (_scans.TryGetValue(id, out var scan))
+        {
+            scan.Status = ScanStatus.Completed;
+            scan.CompletedAt = DateTime.UtcNow;
+            scan.RetailersFound = retailersFound;
+        }
+    }
+
+    public void FailScan(Guid id)
+    {
+        if (_scans.TryGetValue(id, out var scan))
+        {
+            scan.Status = ScanStatus.Failed;
+            scan.CompletedAt = DateTime.UtcNow;
+        }
+    }
+}

--- a/src/DeadStockHair.Api/DeadStockHair.Api.csproj
+++ b/src/DeadStockHair.Api/DeadStockHair.Api.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.13" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DeadStockHair.ServiceDefaults\DeadStockHair.ServiceDefaults.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/DeadStockHair.Api/DeadStockHair.Api.http
+++ b/src/DeadStockHair.Api/DeadStockHair.Api.http
@@ -1,0 +1,25 @@
+@DeadStockHair.Api_HostAddress = http://localhost:5128
+
+### Get all retailers
+GET {{DeadStockHair.Api_HostAddress}}/api/retailers
+Accept: application/json
+
+### Search retailers
+GET {{DeadStockHair.Api_HostAddress}}/api/retailers?search=hair
+Accept: application/json
+
+### Get retailer stats
+GET {{DeadStockHair.Api_HostAddress}}/api/retailers/stats
+Accept: application/json
+
+### Start a scan
+POST {{DeadStockHair.Api_HostAddress}}/api/scan
+Accept: application/json
+
+### Get latest scan
+GET {{DeadStockHair.Api_HostAddress}}/api/scan/latest
+Accept: application/json
+
+### Get saved retailers
+GET {{DeadStockHair.Api_HostAddress}}/api/saved
+Accept: application/json

--- a/src/DeadStockHair.Api/Endpoints/RetailerEndpoints.cs
+++ b/src/DeadStockHair.Api/Endpoints/RetailerEndpoints.cs
@@ -1,0 +1,64 @@
+using DeadStockHair.Api.Data;
+using DeadStockHair.Api.Models;
+
+namespace DeadStockHair.Api.Endpoints;
+
+public static class RetailerEndpoints
+{
+    public static RouteGroupBuilder MapRetailerEndpoints(this WebApplication app)
+    {
+        var group = app.MapGroup("/api/retailers").WithTags("Retailers");
+
+        group.MapGet("/", (RetailerStore store, string? search) =>
+        {
+            var retailers = string.IsNullOrWhiteSpace(search)
+                ? store.GetAllRetailers()
+                : store.SearchRetailers(search);
+
+            return Results.Ok(retailers);
+        })
+        .WithName("GetRetailers")
+        .WithSummary("Get all retailers, optionally filtered by search query");
+
+        group.MapGet("/stats", (RetailerStore store) =>
+        {
+            return Results.Ok(store.GetStats());
+        })
+        .WithName("GetRetailerStats")
+        .WithSummary("Get retailer statistics");
+
+        group.MapGet("/{id:guid}", (Guid id, RetailerStore store) =>
+        {
+            var retailer = store.GetRetailer(id);
+            return retailer is not null ? Results.Ok(retailer) : Results.NotFound();
+        })
+        .WithName("GetRetailerById")
+        .WithSummary("Get a retailer by ID");
+
+        group.MapPost("/", (CreateRetailerRequest request, RetailerStore store) =>
+        {
+            var retailer = new Retailer
+            {
+                Name = request.Name,
+                Url = request.Url,
+                Status = request.Status ?? RetailerStatus.Unknown
+            };
+
+            store.AddRetailer(retailer);
+            return Results.Created($"/api/retailers/{retailer.Id}", retailer);
+        })
+        .WithName("CreateRetailer")
+        .WithSummary("Add a new retailer");
+
+        group.MapDelete("/{id:guid}", (Guid id, RetailerStore store) =>
+        {
+            return store.DeleteRetailer(id) ? Results.NoContent() : Results.NotFound();
+        })
+        .WithName("DeleteRetailer")
+        .WithSummary("Delete a retailer");
+
+        return group;
+    }
+}
+
+public record CreateRetailerRequest(string Name, string Url, RetailerStatus? Status = null);

--- a/src/DeadStockHair.Api/Endpoints/SavedEndpoints.cs
+++ b/src/DeadStockHair.Api/Endpoints/SavedEndpoints.cs
@@ -1,0 +1,44 @@
+using DeadStockHair.Api.Data;
+
+namespace DeadStockHair.Api.Endpoints;
+
+public static class SavedEndpoints
+{
+    public static RouteGroupBuilder MapSavedEndpoints(this WebApplication app)
+    {
+        var group = app.MapGroup("/api/saved").WithTags("Saved");
+
+        group.MapGet("/", (RetailerStore store) =>
+        {
+            return Results.Ok(store.GetSavedRetailers());
+        })
+        .WithName("GetSavedRetailers")
+        .WithSummary("Get all saved/bookmarked retailers");
+
+        group.MapPost("/{retailerId:guid}", (Guid retailerId, RetailerStore store) =>
+        {
+            var saved = store.SaveRetailer(retailerId);
+            return saved is not null
+                ? Results.Ok(saved)
+                : Results.NotFound(new { message = "Retailer not found" });
+        })
+        .WithName("SaveRetailer")
+        .WithSummary("Save/bookmark a retailer");
+
+        group.MapDelete("/{retailerId:guid}", (Guid retailerId, RetailerStore store) =>
+        {
+            return store.UnsaveRetailer(retailerId) ? Results.NoContent() : Results.NotFound();
+        })
+        .WithName("UnsaveRetailer")
+        .WithSummary("Remove a saved retailer");
+
+        group.MapGet("/{retailerId:guid}/status", (Guid retailerId, RetailerStore store) =>
+        {
+            return Results.Ok(new { isSaved = store.IsRetailerSaved(retailerId) });
+        })
+        .WithName("GetSavedStatus")
+        .WithSummary("Check if a retailer is saved");
+
+        return group;
+    }
+}

--- a/src/DeadStockHair.Api/Endpoints/ScanEndpoints.cs
+++ b/src/DeadStockHair.Api/Endpoints/ScanEndpoints.cs
@@ -1,0 +1,58 @@
+using DeadStockHair.Api.Data;
+using DeadStockHair.Api.Models;
+
+namespace DeadStockHair.Api.Endpoints;
+
+public static class ScanEndpoints
+{
+    public static RouteGroupBuilder MapScanEndpoints(this WebApplication app)
+    {
+        var group = app.MapGroup("/api/scan").WithTags("Scan");
+
+        group.MapPost("/", (RetailerStore store) =>
+        {
+            var scan = store.CreateScan();
+
+            // Simulate async scan completion in the background
+            _ = Task.Run(async () =>
+            {
+                await Task.Delay(3000);
+
+                var newRetailers = new[]
+                {
+                    new Retailer { Name = "Belle Hair Studio", Url = "bellehair.com", Status = RetailerStatus.InStock },
+                    new Retailer { Name = "Strand Supply Co", Url = "strandsupply.com", Status = RetailerStatus.Unknown },
+                };
+
+                foreach (var retailer in newRetailers)
+                {
+                    store.AddRetailer(retailer);
+                }
+
+                store.CompleteScan(scan.Id, newRetailers.Length);
+            });
+
+            return Results.Accepted($"/api/scan/{scan.Id}", scan);
+        })
+        .WithName("StartScan")
+        .WithSummary("Trigger a new retailer scan");
+
+        group.MapGet("/{id:guid}", (Guid id, RetailerStore store) =>
+        {
+            var scan = store.GetScan(id);
+            return scan is not null ? Results.Ok(scan) : Results.NotFound();
+        })
+        .WithName("GetScanStatus")
+        .WithSummary("Get the status of a scan");
+
+        group.MapGet("/latest", (RetailerStore store) =>
+        {
+            var scan = store.GetLatestScan();
+            return scan is not null ? Results.Ok(scan) : Results.NotFound();
+        })
+        .WithName("GetLatestScan")
+        .WithSummary("Get the most recent scan result");
+
+        return group;
+    }
+}

--- a/src/DeadStockHair.Api/Models/Retailer.cs
+++ b/src/DeadStockHair.Api/Models/Retailer.cs
@@ -1,0 +1,18 @@
+namespace DeadStockHair.Api.Models;
+
+public class Retailer
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public required string Name { get; set; }
+    public required string Url { get; set; }
+    public RetailerStatus Status { get; set; } = RetailerStatus.InStock;
+    public DateTime DiscoveredAt { get; set; } = DateTime.UtcNow;
+    public DateTime? LastCheckedAt { get; set; }
+}
+
+public enum RetailerStatus
+{
+    InStock,
+    OutOfStock,
+    Unknown
+}

--- a/src/DeadStockHair.Api/Models/RetailerStats.cs
+++ b/src/DeadStockHair.Api/Models/RetailerStats.cs
@@ -1,0 +1,3 @@
+namespace DeadStockHair.Api.Models;
+
+public record RetailerStats(int TotalRetailers, int InStock, int NewThisWeek);

--- a/src/DeadStockHair.Api/Models/SavedRetailer.cs
+++ b/src/DeadStockHair.Api/Models/SavedRetailer.cs
@@ -1,0 +1,8 @@
+namespace DeadStockHair.Api.Models;
+
+public class SavedRetailer
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public Guid RetailerId { get; set; }
+    public DateTime SavedAt { get; set; } = DateTime.UtcNow;
+}

--- a/src/DeadStockHair.Api/Models/ScanResult.cs
+++ b/src/DeadStockHair.Api/Models/ScanResult.cs
@@ -1,0 +1,18 @@
+namespace DeadStockHair.Api.Models;
+
+public class ScanResult
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public ScanStatus Status { get; set; } = ScanStatus.Pending;
+    public DateTime StartedAt { get; set; } = DateTime.UtcNow;
+    public DateTime? CompletedAt { get; set; }
+    public int RetailersFound { get; set; }
+}
+
+public enum ScanStatus
+{
+    Pending,
+    Running,
+    Completed,
+    Failed
+}

--- a/src/DeadStockHair.Api/Program.cs
+++ b/src/DeadStockHair.Api/Program.cs
@@ -1,0 +1,37 @@
+using DeadStockHair.Api.Data;
+using DeadStockHair.Api.Endpoints;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.AddServiceDefaults();
+
+builder.Services.AddSingleton<RetailerStore>();
+
+builder.Services.AddOpenApi();
+
+builder.Services.AddCors(options =>
+{
+    options.AddDefaultPolicy(policy =>
+    {
+        policy.AllowAnyOrigin()
+              .AllowAnyMethod()
+              .AllowAnyHeader();
+    });
+});
+
+var app = builder.Build();
+
+app.MapDefaultEndpoints();
+
+if (app.Environment.IsDevelopment())
+{
+    app.MapOpenApi();
+}
+
+app.UseCors();
+
+app.MapRetailerEndpoints();
+app.MapSavedEndpoints();
+app.MapScanEndpoints();
+
+app.Run();

--- a/src/DeadStockHair.Api/Properties/launchSettings.json
+++ b/src/DeadStockHair.Api/Properties/launchSettings.json
@@ -1,0 +1,23 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5128",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "https://localhost:7094;http://localhost:5128",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/DeadStockHair.Api/appsettings.Development.json
+++ b/src/DeadStockHair.Api/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/DeadStockHair.Api/appsettings.json
+++ b/src/DeadStockHair.Api/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/DeadStockHair.AppHost/DeadStockHair.AppHost.csproj
+++ b/src/DeadStockHair.AppHost/DeadStockHair.AppHost.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Sdk Name="Aspire.AppHost.Sdk" Version="9.1.0" />
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsAspireHost>true</IsAspireHost>
+    <UserSecretsId>70a48181-cd57-4fd7-a6dc-e7ab37b07689</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DeadStockHair.Api\DeadStockHair.Api.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/DeadStockHair.AppHost/Program.cs
+++ b/src/DeadStockHair.AppHost/Program.cs
@@ -1,0 +1,5 @@
+var builder = DistributedApplication.CreateBuilder(args);
+
+var api = builder.AddProject<Projects.DeadStockHair_Api>("api");
+
+builder.Build().Run();

--- a/src/DeadStockHair.AppHost/Properties/launchSettings.json
+++ b/src/DeadStockHair.AppHost/Properties/launchSettings.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:17213;http://localhost:15099",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21233",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22054"
+      }
+    },
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:15099",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19058",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20296"
+      }
+    }
+  }
+}

--- a/src/DeadStockHair.AppHost/appsettings.Development.json
+++ b/src/DeadStockHair.AppHost/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/DeadStockHair.AppHost/appsettings.json
+++ b/src/DeadStockHair.AppHost/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "Aspire.Hosting.Dcp": "Warning"
+    }
+  }
+}

--- a/src/DeadStockHair.ServiceDefaults/DeadStockHair.ServiceDefaults.csproj
+++ b/src/DeadStockHair.ServiceDefaults/DeadStockHair.ServiceDefaults.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsAspireSharedProject>true</IsAspireSharedProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.1.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.2" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.11.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.11.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.11.1" />
+  </ItemGroup>
+
+</Project>

--- a/src/DeadStockHair.ServiceDefaults/Extensions.cs
+++ b/src/DeadStockHair.ServiceDefaults/Extensions.cs
@@ -1,0 +1,118 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.ServiceDiscovery;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
+namespace Microsoft.Extensions.Hosting;
+
+// Adds common .NET Aspire services: service discovery, resilience, health checks, and OpenTelemetry.
+// This project should be referenced by each service project in your solution.
+// To learn more about using this project, see https://aka.ms/dotnet/aspire/service-defaults
+public static class Extensions
+{
+    public static IHostApplicationBuilder AddServiceDefaults(this IHostApplicationBuilder builder)
+    {
+        builder.ConfigureOpenTelemetry();
+
+        builder.AddDefaultHealthChecks();
+
+        builder.Services.AddServiceDiscovery();
+
+        builder.Services.ConfigureHttpClientDefaults(http =>
+        {
+            // Turn on resilience by default
+            http.AddStandardResilienceHandler();
+
+            // Turn on service discovery by default
+            http.AddServiceDiscovery();
+        });
+
+        // Uncomment the following to restrict the allowed schemes for service discovery.
+        // builder.Services.Configure<ServiceDiscoveryOptions>(options =>
+        // {
+        //     options.AllowedSchemes = ["https"];
+        // });
+
+        return builder;
+    }
+
+    public static IHostApplicationBuilder ConfigureOpenTelemetry(this IHostApplicationBuilder builder)
+    {
+        builder.Logging.AddOpenTelemetry(logging =>
+        {
+            logging.IncludeFormattedMessage = true;
+            logging.IncludeScopes = true;
+        });
+
+        builder.Services.AddOpenTelemetry()
+            .WithMetrics(metrics =>
+            {
+                metrics.AddAspNetCoreInstrumentation()
+                    .AddHttpClientInstrumentation()
+                    .AddRuntimeInstrumentation();
+            })
+            .WithTracing(tracing =>
+            {
+                tracing.AddAspNetCoreInstrumentation()
+                    // Uncomment the following line to enable gRPC instrumentation (requires the OpenTelemetry.Instrumentation.GrpcNetClient package)
+                    //.AddGrpcClientInstrumentation()
+                    .AddHttpClientInstrumentation();
+            });
+
+        builder.AddOpenTelemetryExporters();
+
+        return builder;
+    }
+
+    private static IHostApplicationBuilder AddOpenTelemetryExporters(this IHostApplicationBuilder builder)
+    {
+        var useOtlpExporter = !string.IsNullOrWhiteSpace(builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"]);
+
+        if (useOtlpExporter)
+        {
+            builder.Services.AddOpenTelemetry().UseOtlpExporter();
+        }
+
+        // Uncomment the following lines to enable the Azure Monitor exporter (requires the Azure.Monitor.OpenTelemetry.AspNetCore package)
+        //if (!string.IsNullOrEmpty(builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"]))
+        //{
+        //    builder.Services.AddOpenTelemetry()
+        //       .UseAzureMonitor();
+        //}
+
+        return builder;
+    }
+
+    public static IHostApplicationBuilder AddDefaultHealthChecks(this IHostApplicationBuilder builder)
+    {
+        builder.Services.AddHealthChecks()
+            // Add a default liveness check to ensure app is responsive
+            .AddCheck("self", () => HealthCheckResult.Healthy(), ["live"]);
+
+        return builder;
+    }
+
+    public static WebApplication MapDefaultEndpoints(this WebApplication app)
+    {
+        // Adding health checks endpoints to applications in non-development environments has security implications.
+        // See https://aka.ms/dotnet/aspire/healthchecks for details before enabling these endpoints in non-development environments.
+        if (app.Environment.IsDevelopment())
+        {
+            // All health checks must pass for app to be considered ready to accept traffic after starting
+            app.MapHealthChecks("/health");
+
+            // Only health checks tagged with the "live" tag must pass for app to be considered alive
+            app.MapHealthChecks("/alive", new HealthCheckOptions
+            {
+                Predicate = r => r.Tags.Contains("live")
+            });
+        }
+
+        return app;
+    }
+}


### PR DESCRIPTION
Create the backend API microservices architecture using .NET 9.0 and Aspire to support the dead-stock-hair.pen design screens:

- DeadStockHair.AppHost: Aspire orchestrator for distributed app
- DeadStockHair.ServiceDefaults: Shared Aspire defaults (OpenTelemetry, health checks, service discovery, resilience)
- DeadStockHair.Api: Web API with minimal API endpoints for:
  - Retailers: CRUD, search, and stats (total, in-stock, new this week)
  - Scan: trigger retailer discovery scans with async processing
  - Saved: bookmark/unbookmark retailers
- Domain models: Retailer, SavedRetailer, ScanResult, RetailerStats
- In-memory data store seeded with retailers from the design
- Solution file linking all projects including existing CLI

https://claude.ai/code/session_01HLy7v5oyf5NdyLsksimmEE